### PR TITLE
* move projects link from FOSSRIT/tasks to toplevel FOSSRIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is a public ticketing system used by [FOSS@MAGIC](http://foss.ri
 It is used both by students and RIT MAGIC faculty and staff.
 Its purpose is to track progress of on-going and upcoming tasks and help prioritize focus.
 Tasks are created as **issues** in the GitHub interface.
-The [project board](https://github.com/FOSSRIT/tasks/projects/1?fullscreen=true) uses kanban to organize and track progress.
+The [project board](https://github.com/orgs/FOSSRIT/projects/1?fullscreen=true) uses kanban to organize and track progress.
 
 
 ## License


### PR DESCRIPTION
Closes #67 

Should have been on a feature branch, anyway. So much for taking shortcuts. See also #68